### PR TITLE
Add means for sending help to a specific user

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ handy things.
 ## Commands
 
 <dl>
+  <dt>!help [USER]</dt>
+  <dd>Show usage information (optionally mention a specific user)</dd>
+
   <dt>!inspace</dt>
   <dd>Shortcut: i. List the members currently present.</dd>
 

--- a/lib/Modules/Help.js
+++ b/lib/Modules/Help.js
@@ -8,7 +8,16 @@ class Help {
     }
 
     onHelp(channel, nickname, command, payload) {
-        this.irc.answer(channel, nickname, 'see https://github.com/b4ckspace/node-ircbot');
+        if (payload === '') {
+            this.sendHelp(channel, nickname);
+        } else {
+            this.sendHelp(channel, payload);
+        }
+    }
+
+    sendHelp(channel, nickname) {
+        this.irc.answer(channel, nickname,
+                        'see https://github.com/b4ckspace/node-ircbot');
     }
 }
 


### PR DESCRIPTION
Motivation: In some situations you may want to help some user with the bot by
having the bot directly offer help to that user.

I added an optional parameter to the `help` command, which takes a nickname and
makes the bot offer help to that specific user by mentioning him instead of the
user invoking the `help` command.